### PR TITLE
Update .htaccess to include Google Gemini User Agent

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -3,7 +3,7 @@
   RewriteBase /
   #HTML--------------------------------------------------
   # User-agents
-  RewriteCond %{HTTP_USER_AGENT} (CCBot|ChatGPT|GPTBot|anthropic-ai|Omgilibot|Omgili|FacebookBot) [OR,NC]
+  RewriteCond %{HTTP_USER_AGENT} (CCBot|ChatGPT|GPTBot|anthropic-ai|Omgilibot|Omgili|FacebookBot|Google-Extended) [OR,NC]
   # OpenIA - ChatGPT
   RewriteCond %{REMOTE_ADDR} ^20\.15\.240\. [OR]
   RewriteCond %{REMOTE_ADDR} ^20\.15\.241\. [OR]
@@ -18,7 +18,7 @@
 
   #IMAGES--------------------------------------------------
   # User-agents
-  RewriteCond %{HTTP_USER_AGENT} (CCBot|ChatGPT|GPTBot|anthropic-ai|Omgilibot|Omgili|FacebookBot) [OR,NC]
+  RewriteCond %{HTTP_USER_AGENT} (CCBot|ChatGPT|GPTBot|anthropic-ai|Omgilibot|Omgili|FacebookBot|Google-Extended) [OR,NC]
   # OpenIA - ChatGPT
   RewriteCond %{REMOTE_ADDR} ^20\.15\.240\. [OR]
   RewriteCond %{REMOTE_ADDR} ^20\.15\.241\. [OR]


### PR DESCRIPTION
Google usa el "User-Agent token" `Google-Extended` para las apps de Gemini (ver https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers#google-extended).